### PR TITLE
Display check result messages in full instead of in a tooltip

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -337,7 +337,7 @@ export function DisplayStatus({
   };
   return (
     <a title={message} href={url}>
-      <Alert message={status} type={statusToLabelClass[status]} showIcon />
+      <Alert message={message} type={statusToLabelClass[status]} showIcon />
     </a>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -280,7 +280,7 @@ describe('<DisplayStatus />', () => {
     expect(link.prop('title')).toEqual('check message');
     const alert = wrapper.find(Alert);
     expect(alert.prop('type')).toBe(label);
-    expect(link.text()).toEqual(status);
+    expect(link.text()).toEqual('check message');
   };
   it('displays the status when the status is exists', () => {
     checkDisplayStatus('exists', 'success');


### PR DESCRIPTION
Fixes #85