### PR TITLE
The devedition isn't a channel in the 'Firefox' product anymore in Pollbot, fix the tests

### DIFF
--- a/src/PollbotAPI.test.js
+++ b/src/PollbotAPI.test.js
@@ -12,7 +12,6 @@ describe('getOngoingVersions', () => {
     const onGoingVersions = await getOngoingVersions();
     expect(onGoingVersions).toMatchObject({
       beta: expect.any(String),
-      devedition: expect.any(String),
       esr: expect.any(String),
       nightly: expect.any(String),
       release: expect.any(String),


### PR DESCRIPTION
Fixes #147