### PR TITLE
update yarn.lock for flow-bin

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,9 +3085,9 @@ flow-annotation-check@1.3.1:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@^0.63.1:
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.63.1.tgz#ab00067c197169a5fb5b4996c8f6927b06694828"
+flow-bin@^0.64.0:
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.64.0.tgz#ddd3fb3b183ab1ab35a5d5dec9caf5ebbcded167"
 
 flow-coverage-report@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
The `yarn.lock` had `flow-bin` 0.63.1 and `package.json` had `^0.64.0` so running `yarn` on the master branch causes `yarn.lock` to update. 