### PR TITLE
no need to load auth0, fixes #169

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://cdn.auth0.com/js/auth0/8.9/auth0.min.js"></script>
     <title>Delivery Dashboard</title>
   </head>
   <body>


### PR DESCRIPTION
At first I thought I'd just comment it out like we do with the Login button jsx code but, suppose that we do decide to go back and add Auth0, we shouldn't include the CDN file in the template but instead load it as a proper module. 