### PR TITLE
make DisplayCheckResult pure component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -352,11 +352,11 @@ export function Dashboard({
         <div className="dashboard">
           {releaseInfo.checks.map(check =>
             // Map on the checklist to display the results in the same order.
-            DisplayCheckResult(
-              check.title,
-              check.actionable,
-              checkResults[check.title],
-            ),
+            <DisplayCheckResult
+              title={check.title}
+              actionable={check.actionable}
+              checkResult={checkResults[check.title]}
+            />
           )}
         </div>
       </div>
@@ -407,35 +407,44 @@ export function OverallStatus({
   );
 }
 
-export function DisplayCheckResult(
+type DisplayCheckResultProps = {
   title: string,
   actionable: boolean,
-  checkResult: ?CheckResult,
-) {
-  let titleContent = title;
-  if (!actionable) {
-    titleContent = (
-      <div>
-        <Tooltip title="This check is not actionable">
-          <Icon type="notification" /> {title}
-        </Tooltip>
-      </div>
+  checkResult: CheckResult
+}
+class DisplayCheckResult extends React.PureComponent<DisplayCheckResultProps, void> {
+  render() {
+    const { title, actionable, checkResult} = this.props;
+    let titleContent = title;
+    if (!actionable) {
+      titleContent = (
+        <div>
+          <Tooltip title="This check is not actionable">
+            <Icon type="notification" /> {title}
+          </Tooltip>
+        </div>
+      );
+    }
+    return (
+      <Card
+        title={titleContent}
+        key={title}
+        noHovering={true}
+        style={{textAlign: 'center'}}
+      >
+        {checkResult ? (
+          <DisplayStatus
+            status={checkResult.status}
+            message={checkResult.message}
+            url={checkResult.link}
+            actionable={actionable}
+          />
+        ) : (
+          <Spin />
+        )}
+      </Card>
     );
   }
-  return (
-    <Card title={titleContent} key={title} style={{textAlign: 'center'}}>
-      {checkResult ? (
-        <DisplayStatus
-          status={checkResult.status}
-          message={checkResult.message}
-          url={checkResult.link}
-          actionable={actionable}
-        />
-      ) : (
-        <Spin />
-      )}
-    </Card>
-  );
 }
 
 export function DisplayStatus({

--- a/src/App.js
+++ b/src/App.js
@@ -350,14 +350,15 @@ export function Dashboard({
           />
         </h2>
         <div className="dashboard">
-          {releaseInfo.checks.map(check =>
+          {releaseInfo.checks.map(check => (
             // Map on the checklist to display the results in the same order.
             <DisplayCheckResult
+              key={check.title}
               title={check.title}
               actionable={check.actionable}
               checkResult={checkResults[check.title]}
             />
-          )}
+          ))}
         </div>
       </div>
     );
@@ -410,11 +411,14 @@ export function OverallStatus({
 type DisplayCheckResultProps = {
   title: string,
   actionable: boolean,
-  checkResult: CheckResult
-}
-class DisplayCheckResult extends React.PureComponent<DisplayCheckResultProps, void> {
+  checkResult: CheckResult,
+};
+class DisplayCheckResult extends React.PureComponent<
+  DisplayCheckResultProps,
+  void,
+> {
   render() {
-    const { title, actionable, checkResult} = this.props;
+    const {title, actionable, checkResult} = this.props;
     let titleContent = title;
     if (!actionable) {
       titleContent = (
@@ -426,12 +430,7 @@ class DisplayCheckResult extends React.PureComponent<DisplayCheckResultProps, vo
       );
     }
     return (
-      <Card
-        title={titleContent}
-        key={title}
-        noHovering={true}
-        style={{textAlign: 'center'}}
-      >
+      <Card title={titleContent} key={title} style={{textAlign: 'center'}}>
         {checkResult ? (
           <DisplayStatus
             status={checkResult.status}

--- a/src/App.js
+++ b/src/App.js
@@ -351,7 +351,6 @@ export function Dashboard({
         </h2>
         <div className="dashboard">
           {releaseInfo.checks.map(check => (
-            // Map on the checklist to display the results in the same order.
             <DisplayCheckResult
               key={check.title}
               title={check.title}
@@ -413,7 +412,7 @@ type DisplayCheckResultProps = {
   actionable: boolean,
   checkResult: CheckResult,
 };
-class DisplayCheckResult extends React.PureComponent<
+export class DisplayCheckResult extends React.PureComponent<
   DisplayCheckResultProps,
   void,
 > {
@@ -430,7 +429,7 @@ class DisplayCheckResult extends React.PureComponent<
       );
     }
     return (
-      <Card title={titleContent} key={title} style={{textAlign: 'center'}}>
+      <Card title={titleContent} style={{textAlign: 'center'}}>
         {checkResult ? (
           <DisplayStatus
             status={checkResult.status}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,6 +6,7 @@ import {
   App,
   ConnectedApp,
   Dashboard,
+  DisplayCheckResult,
   DisplayStatus,
   Errors,
   LoginButton,
@@ -365,7 +366,7 @@ describe('<Dashboard />', () => {
       />,
     );
     expect(wrapper.find(Spin).length).toBe(0);
-    expect(wrapper.find(DisplayStatus).length).toBe(2);
+    expect(wrapper.find(DisplayCheckResult).length).toBe(2);
   });
   it("displays an extra icon and tooltip on the checks that aren't actionable", () => {
     const wrapper = mount(


### PR DESCRIPTION
This makes the `DisplayCheckResult` a pure component. 
Effect is slightly faster rendering which might be negligable so perhaps the cost of not using function instead of React components isn't desirable. 

This is my first ever project that uses Flow so I'm not entirely sure I'm doing this right. 

I put a `console.log` inside `DisplayCheckResult` and it re-renders every time the interval timer reloads which it only needs to do for the Telemetry check. 
After this change, the `DisplayCheckResult` only renders for the `Telemetry Main Summary Uptake (24h latency)` card. 

