### PR TITLE
hoverable instead of noHovering, fixes #184

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -423,7 +423,6 @@ export function DisplayCheckResult(
     <Card
       title={titleContent}
       key={title}
-      noHovering={true}
       style={{textAlign: 'center'}}
     >
       {checkResult ? (

--- a/src/App.js
+++ b/src/App.js
@@ -420,11 +420,7 @@ export function DisplayCheckResult(
     );
   }
   return (
-    <Card
-      title={titleContent}
-      key={title}
-      style={{textAlign: 'center'}}
-    >
+    <Card title={titleContent} key={title} style={{textAlign: 'center'}}>
       {checkResult ? (
         <DisplayStatus
           status={checkResult.status}


### PR DESCRIPTION
`noHovering` isn't even mentioned in [the documentation](https://ant.design/components/card/#Card) any more. 