### PR TITLE
Prettier css

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,17 @@
     "build:readme": "toctoc -w -d 2 README.md",
     "prebuild": "yarn run version-file",
     "test": "NODE_ENV=test react-app-rewired test --env=jsdom --silent",
-    "test-coverage": "yarn run test --coverage --collectCoverageFrom=src/**/*js --collectCoverageFrom=!src/index.js --collectCoverageFrom=!src/registerServiceWorker.js",
+    "test-coverage":
+      "yarn run test --coverage --collectCoverageFrom=src/**/*js --collectCoverageFrom=!src/index.js --collectCoverageFrom=!src/registerServiceWorker.js",
     "eject": "react-app-rewired eject",
     "deploy": "yarn run build && gh-pages --add --dist build/",
-    "deploy-dev": "PUBLIC_URL=$npm_package_homepage_dev yarn run deploy --dest dev/",
+    "deploy-dev":
+      "PUBLIC_URL=$npm_package_homepage_dev yarn run deploy --dest dev/",
     "lint": "eslint *.js src",
     "lint-fix": "yarn lint --fix",
     "flow": "flow",
-    "flow-coverage": "flow-coverage-report -i 'src/**/*.js' -x 'src/**/*.test.js' -t html -t text",
+    "flow-coverage":
+      "flow-coverage-report -i 'src/**/*.js' -x 'src/**/*.test.js' -t html -t text",
     "check": "yarn lint && yarn flow",
     "precheck": "yarn run version-file",
     "version-file": "./update_version.sh"

--- a/src/App.css
+++ b/src/App.css
@@ -57,7 +57,6 @@ header h1 {
   word-wrap: break-word;
 }
 
-
 footer {
   background-color: #fff;
   bottom: 0;
@@ -67,7 +66,6 @@ footer {
   text-align: center;
   width: 100%;
 }
-
 
 @media (max-width: 992px) {
   .user {
@@ -85,9 +83,9 @@ footer {
   }
 
   .ant-card {
-      margin-bottom: 5px;
+    margin-bottom: 5px;
   }
- 
+
   .ant-layout-sider {
     background-color: #fff;
     border-right: 1px solid #e9e9e9;


### PR DESCRIPTION
Now I've changed my Atom so that when I save any `.js` it executes the eslint prettier integration. 
And if I save a `.css` or `.json` it prettier that too but since `yarn lint` can only check `.js` files I don't know how to automate that. 