### PR TITLE
check in our .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+singleQuote: true
+trailingComma: all
+bracketSpacing: false
+jsxBracketSameLine: false
+parser: flow


### PR DESCRIPTION
cc @Natim 

I use Atom and it has a eslint-prettier config option so the prettier rules get read from the `.eslintrc`. That's nice, but I'm not always in Atom. 

By having this file I can now run:
```sh
▶ prettier -l src/*.js

```
Before, that would yield a bunch of differences because the `prettier` command line program couldn't find [our config](https://github.com/mozilla/delivery-dashboard/blob/f8fcdc2320edb0306645eb5f71467a1e36e1afb6/.eslintrc.js#L27-L35).