### PR TITLE
switch delivery dashboard to new pollbot instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import createStore from "./create-store";
 
 const searchParams = new URLSearchParams(window.location.search);
 export const pollbotUrl =
-  searchParams.get("server") || "https://pollbot.services.mozilla.com/v1";
+  searchParams.get("server") || "https://prod.pollbot.prod.webservices.mozgcp.net/v1";
 
 const root = document && document.getElementById("root");
 


### PR DESCRIPTION
Pollbot is migrating to GCPv2 in https://mozilla-hub.atlassian.net/browse/SVCSE-2775. Once we're happy with that instance we'll cut Delivery Dashboard over to it.